### PR TITLE
Implement workers utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Common functionality shared throughout Clinic.js.
   - [Utils](#utils)
     - [`getLoggingPaths(toolName, toolSpecificFiles=[])`](#getloggingpathstoolname-toolspecificfiles)
     - [`checkForTranspiledCode(fileName)`](#checkfortranspiledcode-filename)
+    - [`workers`](#workers)
   - [Scripts](#scripts)
     - [`buildJs(opts = {})`](#buildjsopts)
       - [Usage](#usage)
@@ -68,6 +69,19 @@ A function that will check file contents for transpiled code. Check also include
 
 Arguments:
   - `fileName` - Path to the file being passed in.
+
+### `workers`
+
+An object that provides an information about Node.js worker thread support.
+
+```js
+const { workers } = require('@nearform/node-clinic-common')
+
+console.log(workers.isMainThread)
+console.log(workers.threadId)
+```
+
+If Worker Threads are not supported on the Node.js version used, the `isMainThread` property will be `true`, and the `threadId` property will be `0`.
 
 ***
 
@@ -408,7 +422,7 @@ style can be customised by defining these CSS vars in your CSS
 ### contexOverlay
 Displays an overlay containig the given `msg` right next to the targetElement or the targetRect
 
-If **targetElement** and **targetRect** are `null||undefined` then the overlay content will be centerd on the page. 
+If **targetElement** and **targetRect** are `null||undefined` then the overlay content will be centerd on the page.
 ```js
   // const options = {
   //   msg,
@@ -426,7 +440,7 @@ If **targetElement** and **targetRect** are `null||undefined` then the overlay c
       offset: { y: 10, height: 20 },
       targetElement: document.querySelector('.my-cool-element'),
       showArrow: true
-    })  
+    })
 ```
 
 ### Walkthrough

--- a/index.js
+++ b/index.js
@@ -2,8 +2,10 @@
 
 const getLoggingPaths = require('./lib/get-logging-paths')
 const checkForTranspiledCode = require('./lib/source-check')
+const workers = require('./lib/workers')
 
 module.exports = {
   getLoggingPaths,
-  checkForTranspiledCode
+  checkForTranspiledCode,
+  workers
 }

--- a/lib/workers.js
+++ b/lib/workers.js
@@ -1,0 +1,16 @@
+'use strict'
+
+function maybeWorkerThreads () {
+  let isMainThread = true
+  let threadId = 0
+  try {
+    const workerThreads = require('worker_threads')
+    isMainThread = workerThreads.isMainThread
+    threadId = workerThreads.threadId
+  } catch (err) {
+    // Do nothing
+  }
+  return { isMainThread, threadId }
+}
+
+module.exports = maybeWorkerThreads()

--- a/test/workers.test.js
+++ b/test/workers.test.js
@@ -1,0 +1,34 @@
+const test = require('tap').test
+const workers = require('../lib/workers.js')
+
+function hasWorkerThreads () {
+  let hasWorkerThreads = false
+  try {
+    hasWorkerThreads = !!require('worker_threads')
+  } catch (err) {
+    // Do nothing
+  }
+  return hasWorkerThreads
+}
+
+test('test worker thread detection', (t) => {
+  t.strictEqual(workers.isMainThread, true)
+  t.strictEqual(workers.threadId, 0)
+
+  if (hasWorkerThreads()) {
+    const { Worker } = require('worker_threads')
+    const worker = new Worker(`
+const test = require('tap').test
+const workers = require('./lib/workers.js')
+const assert = require('assert')
+assert.strictEqual(workers.isMainThread, false)
+assert.strictEqual(workers.threadId, 1)
+    `, { eval: true })
+    worker.on('exit', (code) => {
+      if (code !== 0) t.fail(`worker test failed with code ${code}`)
+      t.end()
+    })
+  } else {
+    t.end()
+  }
+})


### PR DESCRIPTION
Provides a utility that can be used to determine if the current thread
is the main Node.js thread or a worker thread, even if worker threads
are not supported.

```js
const { workers } = require('@nearform/node-clinic-common')

console.log(workers.isMainThread)
console.log(workers.threadId)
```

If workers are not supported on the Node.js version, `isMainThread` always returns `true` and `threadId` always returns `0`, otherwise returns the appropriate value.