### PR TITLE
Tweak opacity of element highlighter

### DIFF
--- a/base/element-highlighter.js
+++ b/base/element-highlighter.js
@@ -38,7 +38,7 @@ function render () {
       height: 0
     }
 
-  backdropContainer.style.cssText = 'opacity:0.6;'
+  backdropContainer.style.cssText = 'opacity:0.8;'
   backdropTop.style.cssText = `transform:translate3d(${pos.left - padding}px, calc(-100vh + ${pos.top - padding}px), 0)`
   backdropRight.style.cssText = `transform:translate3d(${pos.left + pos.width + padding}px, ${pos.top - padding}px, 0)`
   backdropBottom.style.cssText = `transform:translate3d(calc(-100vw + ${pos.left + pos.width + padding}px), ${pos.top + pos.height + padding}px, 0)`


### PR DESCRIPTION
Issue:
"Content is visible but not interactive (as user is in Guide mode). The cropping mask may not be strong enough for user to realise it."

Fix:
Cropping mask has been made darker to help user realise the content is not interactive.

![image](https://user-images.githubusercontent.com/4488048/82801155-c531ed80-9e74-11ea-9028-283d490b6901.png)
