### PR TITLE
Revert "Bump chalk from 4.1.2 to 5.0.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
   "dependencies": {
     "brfs": "^2.0.1",
     "browserify": "^17.0.0",
-    "chalk": "^5.0.0",
+    "chalk": "^4.1.0",
     "lodash.debounce": "^4.0.8",
     "loose-envify": "^1.4.0",
     "postcss": "^8.1.10",


### PR DESCRIPTION
Reverts clinicjs/node-clinic-common#46